### PR TITLE
TECH-4118 - Enable remote, manual trigger via webhook

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -14,7 +14,10 @@ on:
           - 'development'
           - 'preprod'
   schedule:
-    - cron: '23,53 * * * *'
+    - cron: '3 * * * *'
+  repository_dispatch:
+    types:
+      - manual-trigger-by-devs
 
 env:
   BRANCHES: 'main staging development preprod'


### PR DESCRIPTION
In order to be able to run the webhook, you also need to present a valid token but that's not something that has to be configured here. This `repository_dispatch` is only needed in the default branch.